### PR TITLE
🔧 Update GitHub Workflows for Improved Concurrency and Variable Handling

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,6 +7,9 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 jobs:
   pre-commit:
     name: pre-commit

--- a/.github/workflows/profile-3d-contrib.yml
+++ b/.github/workflows/profile-3d-contrib.yml
@@ -9,7 +9,6 @@ on:
 
 concurrency:
   group: profile-3d-contrib
-  cancel-in-progress: true
 
 permissions:
   contents: write

--- a/.github/workflows/profile-3d-contrib.yml
+++ b/.github/workflows/profile-3d-contrib.yml
@@ -10,15 +10,14 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
     env:
       BRANCH_NAME: feature/generate-github-profile-3d-contrib
     steps:

--- a/.github/workflows/profile-3d-contrib.yml
+++ b/.github/workflows/profile-3d-contrib.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: profile-3d-contrib
+  group: ${{ github.workflow }}-${{ github.ref }}
 
 permissions:
   contents: write

--- a/.github/workflows/profile-3d-contrib.yml
+++ b/.github/workflows/profile-3d-contrib.yml
@@ -24,7 +24,7 @@ jobs:
       BRANCH_NAME: feature/generate-github-profile-3d-contrib
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v4
 
       - name: git switch
         run: |

--- a/.github/workflows/profile-3d-contrib.yml
+++ b/.github/workflows/profile-3d-contrib.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: git switch
         run: |
-          git switch -c "$BRANCH_NAME" >/dev/null 2>&1 || git switch "$BRANCH_NAME"
+          git switch -c "${{ env.BRANCH_NAME }}" >/dev/null 2>&1 || git switch "${{ env.BRANCH_NAME }}"
 
       - name: Profile 3d contrib
         uses: yoshi389111/github-profile-3d-contrib@0.9.0
@@ -40,13 +40,13 @@ jobs:
           git config user.email github-actions@github.com
           git add -A .
           git commit -m "Update profile-3d-contrib"
-          git push -f origin "$BRANCH_NAME"
+          git push -f origin "${{ env.BRANCH_NAME }}"
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7.0.8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          branch: "$BRANCH_NAME"
+          branch: "${{ env.BRANCH_NAME }}"
           base: main
           title: "Update profile-3d-contrib"
           body: "Automated update of profile-3d-contrib files."


### PR DESCRIPTION

## 📒 変更点の概要

- `.github/workflows/profile-3d-contrib.yml` と `.github/workflows/pre-commit.yml` の GitHub Actions ワークフローが更新されました。
- `profile-3d-contrib` ワークフローでのブランチ名の参照方法が修正され、環境変数 `${{ env.BRANCH_NAME }}` を使用するようになりました。
- `profile-3d-contrib` ワークフローの `permissions` セクションが `build` ジョブの下に移動されました。
- `concurrency` グループが動的な値を使用するように更新されました。
- `pre-commit` ワークフローに `concurrency` グループが追加されました。
- `profile-3d-contrib` ワークフローから `cancel-in-progress` オプションが削除されました。
- `actions/checkout` のバージョンが v4 に更新されました。

## ⚒ 技術的な詳細

- **ブランチ名の参照修正**: `git switch` や `git push` コマンドで使用されるブランチ名が、環境変数 `${{ env.BRANCH_NAME }}` を通じて正しく参照されるようになりました。これにより、変数のスコープが明確になり、誤ったブランチ名の使用を防ぎます。
  
- **`permissions` セクションの移動**: `permissions` セクションが `build` ジョブの下に移動され、ジョブごとに権限を設定できるようになりました。これにより、ワークフローのセキュリティが向上します。

- **動的な `concurrency` グループ**: `concurrency` グループが `${{ github.workflow }}-${{ github.ref }}` を使用するようになり、異なるワークフローやブランチ間での競合を防ぎます。

## ⚠ 注意点

- **`cancel-in-progress` オプションの削除**: `profile-3d-contrib` ワークフローから `cancel-in-progress` オプションが削除されました。これにより、同じワークフローが並行して実行される可能性があります。必要に応じて、手動でキャンセルすることを検討してください。

- **`actions/checkout` のバージョン更新**: `actions/checkout` のバージョンが v4 に更新されました。互換性の問題が発生する可能性があるため、他のワークフローやアクションとの互換性を確認してください。