### PR TITLE
🔧 Simplify `profile-3d-contrib` Workflow by Removing Redundant Steps

### DIFF
--- a/.github/workflows/profile-3d-contrib.yml
+++ b/.github/workflows/profile-3d-contrib.yml
@@ -34,14 +34,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           USERNAME: ${{ github.repository_owner }}
 
-      - name: git push
-        run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-          git add -A .
-          git commit -m "Update profile-3d-contrib"
-          git push -f origin "${{ env.BRANCH_NAME }}"
-
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7.0.8
         with:

--- a/.github/workflows/profile-3d-contrib.yml
+++ b/.github/workflows/profile-3d-contrib.yml
@@ -42,11 +42,6 @@ jobs:
           git commit -m "Update profile-3d-contrib"
           git push -f origin "${{ env.BRANCH_NAME }}"
 
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ env.BRANCH_NAME }}
-
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7.0.8
         with:


### PR DESCRIPTION

## 📒 変更点の概要

- `profile-3d-contrib.yml` ワークフローから不要なステップを削除しました。
  - `git push` ステップを削除しました。
  - 冗長な `checkout` ステップを削除しました。

## ⚒ 技術的な詳細

- **`git push` ステップの削除**:
  - ワークフロー内で直接リポジトリに変更をプッシュするステップを削除しました。これにより、ワークフローがよりシンプルになり、GitHub Actions の `create-pull-request` アクションに依存する形に変更されました。
  
- **冗長な `checkout` ステップの削除**:
  - 既にワークフローの初期段階でリポジトリがチェックアウトされているため、重複していた `checkout` ステップを削除しました。これにより、ワークフローの実行時間が短縮され、リソースの無駄を削減します。

## ⚠ 注意点

- 💡 これらの変更により、ワークフローの動作が `create-pull-request` アクションに依存するようになります。アクションのバージョンや設定に変更があった場合は、ワークフローの動作に影響を与える可能性があるため、注意が必要です。