### PR TITLE
🔧 Remove redundant git switch step from GitHub Actions workflow

### DIFF
--- a/.github/workflows/profile-3d-contrib.yml
+++ b/.github/workflows/profile-3d-contrib.yml
@@ -24,10 +24,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: git switch
-        run: |
-          git switch -c "${{ env.BRANCH_NAME }}" >/dev/null 2>&1 || git switch "${{ env.BRANCH_NAME }}"
-
       - name: Profile 3d contrib
         uses: yoshi389111/github-profile-3d-contrib@0.9.0
         env:


### PR DESCRIPTION

## 📒 変更点の概要

- `.github/workflows/profile-3d-contrib.yml` ファイルから不要な `git switch` ステップを削除しました。

## ⚒ 技術的な詳細

- `profile-3d-contrib` ワークフロー内で、リポジトリのブランチを切り替えるための `git switch` ステップが削除されました。
  - このステップは、`actions/checkout@v4` アクションによって既にブランチがチェックアウトされているため、冗長であると判断されました。

## ⚠ 注意点

- この変更により、ワークフローの動作に影響はありませんが、ワークフローの実行が若干効率化されます。