### PR TITLE
🔧 Update `profile-3d-contrib` Workflow to Refine Pull Request Automerge Logic

### DIFF
--- a/.github/workflows/profile-3d-contrib.yml
+++ b/.github/workflows/profile-3d-contrib.yml
@@ -49,7 +49,7 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - name: Pull Request Automerge
-        if: steps.cpr.outputs.pull-request-operation == 'created'
+        # if: steps.cpr.outputs.pull-request-operation == 'created'
         env:
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
         run: |

--- a/.github/workflows/profile-3d-contrib.yml
+++ b/.github/workflows/profile-3d-contrib.yml
@@ -52,10 +52,10 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
         run: |
-          PR_NUMBER="${{ steps.cpr.outputs.pull-request-number }}"
-          MERGEABLE=$(gh pr view "$PR_NUMBER" --json mergeable -q '.mergeable')
-          if [ "$MERGEABLE" = "true" ]; then
+          # PR_NUMBER="${{ steps.cpr.outputs.pull-request-number }}"
+          # MERGEABLE=$(gh pr view "$PR_NUMBER" --json mergeable -q '.mergeable')
+          # if [ "$MERGEABLE" = "true" ]; then
             gh pr merge -R "${{ github.repository }}" --squash --auto "$PR_NUMBER"
-          else
-            echo "PR is not mergeable."
-          fi
+          # else
+          #   echo "PR is not mergeable."
+          # fi

--- a/.github/workflows/profile-3d-contrib.yml
+++ b/.github/workflows/profile-3d-contrib.yml
@@ -40,10 +40,16 @@ jobs:
           title: "Update profile-3d-contrib"
           body: "Automated update of profile-3d-contrib files."
 
-      - name: Enable Pull Request Automerge
-        if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: peter-evans/enable-pull-request-automerge@v3
+      - name: Generate GitHub App Token
+        id: app_token
+        uses: actions/create-github-app-token@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
-          merge-method: squash
+          app-id: ${{ secrets.GHA_APP_ID }}
+          private-key: ${{ secrets.GHA_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Pull Request Automerge
+        if: steps.cpr.outputs.pull-request-operation == 'created'
+        run: |
+          gh pr merge -R "tqer39/tqer39" --squash --auto "${{ steps.cpr.outputs.pull-request-number }}"
+            -H "Accept: application/vnd.github.v3+json"

--- a/.github/workflows/profile-3d-contrib.yml
+++ b/.github/workflows/profile-3d-contrib.yml
@@ -50,6 +50,8 @@ jobs:
 
       - name: Pull Request Automerge
         if: steps.cpr.outputs.pull-request-operation == 'created'
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
         run: |
           gh pr merge -R "tqer39/tqer39" --squash --auto "${{ steps.cpr.outputs.pull-request-number }}"
             -H "Accept: application/vnd.github.v3+json"

--- a/.github/workflows/profile-3d-contrib.yml
+++ b/.github/workflows/profile-3d-contrib.yml
@@ -52,4 +52,4 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
         run: |
-          gh pr merge -R "tqer39/tqer39" --squash --auto "${{ steps.cpr.outputs.pull-request-number }}"
+          gh pr merge -R " ${{ github.repository_owner }}/${{ github.repository }}" --squash --auto "${{ steps.cpr.outputs.pull-request-number }}"

--- a/.github/workflows/profile-3d-contrib.yml
+++ b/.github/workflows/profile-3d-contrib.yml
@@ -32,9 +32,18 @@ jobs:
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7.0.8
+        id: cpr
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: "${{ env.BRANCH_NAME }}"
           base: main
           title: "Update profile-3d-contrib"
           body: "Automated update of profile-3d-contrib files."
+
+      - name: Enable Pull Request Automerge
+        if: steps.cpr.outputs.pull-request-operation == 'created'
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
+          merge-method: squash

--- a/.github/workflows/profile-3d-contrib.yml
+++ b/.github/workflows/profile-3d-contrib.yml
@@ -49,9 +49,7 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - name: Pull Request Automerge
-        # if: steps.cpr.outputs.pull-request-operation == 'created'
         env:
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
         run: |
           gh pr merge -R "tqer39/tqer39" --squash --auto "${{ steps.cpr.outputs.pull-request-number }}"
-            -H "Accept: application/vnd.github.v3+json"

--- a/.github/workflows/profile-3d-contrib.yml
+++ b/.github/workflows/profile-3d-contrib.yml
@@ -52,4 +52,10 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
         run: |
-          gh pr merge -R " ${{ github.repository_owner }}/${{ github.repository }}" --squash --auto "${{ steps.cpr.outputs.pull-request-number }}"
+          PR_NUMBER="${{ steps.cpr.outputs.pull-request-number }}"
+          MERGEABLE=$(gh pr view "$PR_NUMBER" --json mergeable -q '.mergeable')
+          if [ "$MERGEABLE" = "true" ]; then
+            gh pr merge -R "${{ github.repository }}" --squash --auto "$PR_NUMBER"
+          else
+            echo "PR is not mergeable."
+          fi


### PR DESCRIPTION

## 📒 変更点の概要

- `profile-3d-contrib.yml` ワークフローにおいて、プルリクエストの自動マージ機能を改善しました。
- プルリクエストのマージ可能性を確認するロジックを追加し、その後コメントアウトしました。
- リポジトリの参照を動的に取得するように変更しました。

## ⚒ 技術的な詳細

- プルリクエストのマージ可能性を確認するために、`gh pr view` コマンドを使用して `mergeable` 属性を取得し、条件に基づいて自動マージを実行するロジックを追加しました。
- リポジトリの参照を動的に取得するために、`${{ github.repository_owner }}/${{ github.repository }}` を使用しました。
- GitHub App トークンを生成するステップを追加し、プルリクエストの自動マージに使用しました。

## ⚠ 注意点

> [!NOTE]
>
> - 現在、プルリクエストのマージ可能性を確認するロジックはコメントアウトされています。必要に応じて有効化してください。
> - GitHub App トークンの生成には、`GHA_APP_ID` と `GHA_APP_PRIVATE_KEY` のシークレットが必要です。これらが正しく設定されていることを確認してください。