### PR TITLE
🔧 Enhance Error Handling in `profile-3d-contrib` Workflow for Missing PR Number

### DIFF
--- a/.github/workflows/profile-3d-contrib.yml
+++ b/.github/workflows/profile-3d-contrib.yml
@@ -52,10 +52,9 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
         run: |
-          # PR_NUMBER="${{ steps.cpr.outputs.pull-request-number }}"
-          # MERGEABLE=$(gh pr view "$PR_NUMBER" --json mergeable -q '.mergeable')
-          # if [ "$MERGEABLE" = "true" ]; then
-            gh pr merge -R "${{ github.repository }}" --squash --auto "$PR_NUMBER"
-          # else
-          #   echo "PR is not mergeable."
-          # fi
+          PR_NUMBER="${{ steps.cpr.outputs.pull-request-number }}"
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No PR number found. Exiting."
+            exit 1
+          fi
+          gh pr merge -R "${{ github.repository }}" --squash --auto "$PR_NUMBER"


### PR DESCRIPTION

## 📒 変更点の概要

- `profile-3d-contrib.yml` GitHub Actions ワークフローにおいて、PR番号が見つからない場合のエラーハンドリングを追加しました。

## ⚒ 技術的な詳細

- `PR_NUMBER` が空の場合にエラーメッセージを出力し、スクリプトを終了するロジックを追加しました。
- 以前のコメントアウトされたコードを削除し、エラーチェックを行った後に `gh pr merge` コマンドを実行するようにしました。

## ⚠ 注意点

- この変更により、PR番号が取得できない場合は自動的にマージ処理が中断されます。これにより、誤ったマージ操作を防ぐことができます。