### PR TITLE
🔧 Enhance PR Approval Workflow with Merged Status Check

### DIFF
--- a/.github/workflows/profile-3d-contrib.yml
+++ b/.github/workflows/profile-3d-contrib.yml
@@ -57,5 +57,16 @@ jobs:
             echo "No PR number found. Exiting."
             exit 1
           fi
+
+          # Approve the PR
           gh pr review "$PR_NUMBER" --approve
+
+          # Check if the PR is already merged after approval
+          MERGED=$(gh pr view "$PR_NUMBER" --json merged -q '.merged')
+          if [ "$MERGED" = "true" ]; then
+            echo "PR is already merged after approval. Exiting."
+            exit 0
+          fi
+
+          # Merge the PR if not already merged
           gh pr merge -R "${{ github.repository }}" --squash --auto "$PR_NUMBER"


### PR DESCRIPTION

## 📒 変更点の概要

- `profile-3d-contrib.yml` GitHub Actions ワークフローに、PR 承認後に既にマージされているかどうかを確認するステップを追加しました。

## ⚒ 技術的な詳細

- `gh pr review "$PR_NUMBER" --approve` コマンドで PR を承認した後、`gh pr view "$PR_NUMBER" --json merged -q '.merged'` コマンドを使用して、PR が既にマージされているかどうかを確認します。
- もし PR が既にマージされている場合は、`echo "PR is already merged after approval. Exiting."` と表示し、スクリプトを終了します。
- PR がまだマージされていない場合は、`gh pr merge -R "${{ github.repository }}" --squash --auto "$PR_NUMBER"` コマンドを使用して自動的にマージを行います。

## ⚠ 注意点

- この変更により、PR 承認後に重複してマージを試みることを防ぎ、ワークフローの効率を向上させます。
- 既にマージされている PR に対しては、無駄なマージ操作を行わないように設計されています。