### PR TITLE
🔄 Simplify PR Approval Process in `profile-3d-contrib` Workflow

### DIFF
--- a/.github/workflows/profile-3d-contrib.yml
+++ b/.github/workflows/profile-3d-contrib.yml
@@ -59,14 +59,5 @@ jobs:
           fi
 
           # Approve the PR
-          gh pr review "$PR_NUMBER" --approve
-
-          # Check if the PR is already merged after approval
-          MERGED=$(gh pr view "$PR_NUMBER" --json merged -q '.merged')
-          if [ "$MERGED" = "true" ]; then
-            echo "PR is already merged after approval. Exiting."
-            exit 0
-          fi
-
-          # Merge the PR if not already merged
           gh pr merge -R "${{ github.repository }}" --squash --auto "$PR_NUMBER"
+          gh pr review "$PR_NUMBER" --approve


### PR DESCRIPTION

## 📒 変更点の概要

- `profile-3d-contrib.yml` ワークフロー内のプルリクエスト承認プロセスをリファクタリングしました。具体的には、承認後にプルリクエストが既にマージされているかどうかを確認する冗長なステップを削除しました。

## ⚒ 技術的な詳細

- `gh pr review "$PR_NUMBER" --approve` コマンドでプルリクエストを承認します。
- 承認後、`gh pr merge -R "${{ github.repository }}" --squash --auto "$PR_NUMBER"` コマンドを使用して、プルリクエストを自動的にマージします。
- 以前は、承認後にプルリクエストが既にマージされているかを確認し、マージ済みであればプロセスを終了するロジックが含まれていましたが、これを削除しました。

## ⚠ 注意点

- この変更により、プルリクエストが承認された後は、即座にマージが試みられます。以前のようにマージ済みかどうかを確認するステップはありませんので、承認のタイミングに注意が必要です。