### PR TITLE
🐛 Cloud Services アイコンのレイアウト崩れを修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,23 +64,7 @@
 
 ## 🌍 Cloud Services I've Used
 
-<p>
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://cdn.simpleicons.org/vercel/white" />
-    <img src="https://cdn.simpleicons.org/vercel" alt="Vercel" width="40" height="40" title="Vercel" />
-  </picture>
-  <img src="https://cdn.simpleicons.org/cloudflare" alt="Cloudflare" width="40" height="40" title="Cloudflare" />
-  <img src="./src/icon/iaas/neon.svg" alt="Neon" width="40" height="40" title="Neon" />
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://cdn.simpleicons.org/flydotio/ffffff" />
-    <img src="https://cdn.simpleicons.org/flydotio" alt="Fly.io" width="40" height="40" title="Fly.io" />
-  </picture>
-  <img src="https://cdn.simpleicons.org/1password" alt="1Password" width="40" height="40" title="1Password" />
-  <img src="https://cdn.simpleicons.org/gitlab" alt="GitLab" width="40" height="40" title="GitLab" />
-  <img src="https://cdn.simpleicons.org/datadog" alt="Datadog" width="40" height="40" title="Datadog" />
-  <img src="./src/icon/iaas/slack.svg" alt="Slack" width="40" height="40" title="Slack" />
-  <img src="https://cdn.simpleicons.org/discord" alt="Discord" width="40" height="40" title="Discord" />
-</p>
+<p><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.simpleicons.org/vercel/white" /><img src="https://cdn.simpleicons.org/vercel" alt="Vercel" width="40" height="40" title="Vercel" /></picture> <img src="https://cdn.simpleicons.org/cloudflare" alt="Cloudflare" width="40" height="40" title="Cloudflare" /> <img src="./src/icon/iaas/neon.svg" alt="Neon" width="40" height="40" title="Neon" /> <picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.simpleicons.org/flydotio/ffffff" /><img src="https://cdn.simpleicons.org/flydotio" alt="Fly.io" width="40" height="40" title="Fly.io" /></picture> <img src="https://cdn.simpleicons.org/1password" alt="1Password" width="40" height="40" title="1Password" /> <img src="https://cdn.simpleicons.org/gitlab" alt="GitLab" width="40" height="40" title="GitLab" /> <img src="https://cdn.simpleicons.org/datadog" alt="Datadog" width="40" height="40" title="Datadog" /> <img src="./src/icon/iaas/slack.svg" alt="Slack" width="40" height="40" title="Slack" /> <img src="https://cdn.simpleicons.org/discord" alt="Discord" width="40" height="40" title="Discord" /></p>
 
 ## 💻 OS
 


### PR DESCRIPTION

このプルリクエストでは、`README.md` ファイル内の Cloud Services アイコンのレイアウトを修正しました。具体的には、アイコンを1行に収めることで、表示が崩れないようにしました。

## 📒 変更の概要

- Cloud Services セクションのアイコンを1行に収めるようにHTMLを修正しました。

## ⚒ 技術的詳細

- `<p>` タグ内のアイコンを1行に並べるために、余分な改行を削除し、すべてのアイコンを1つの `<p>` タグ内に収めました。

## ⚠ 注意点

- 特に注意点はありませんが、表示が正しく行われているかを確認することをお勧めします。